### PR TITLE
R devel support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,27 @@
-language: r
+language: c
 sudo: required
-warnings_are_errors: true
-bioc_required: true
+
+before_install:
+  - curl -OL https://raw.githubusercontent.com/metacran/r-builder/master/pkg-build.sh
+  - chmod 755 pkg-build.sh
+  - ./pkg-build.sh bootstrap
+
+install:
+  - ./pkg-build.sh install_deps
+
+script:
+  - ./pkg-build.sh run_tests
+
+after_failure:
+  - ./pkg-build.sh dump_logs
+
+notifications:
+  email:
+    on_success: change
+    on_failure: change
+
 env:
+  matrix:
+    - RVERSION=release
+    - RVERSION=devel
   - _R_CHECK_CRAN_INCOMING_=FALSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,4 +24,5 @@ env:
   matrix:
     - RVERSION=release
     - RVERSION=devel
-  - _R_CHECK_CRAN_INCOMING_=FALSE
+  global:
+    - _R_CHECK_CRAN_INCOMING_=FALSE

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install:
   - ./pkg-build.sh bootstrap
 
 install:
-  - ./pkg-build.sh install_deps
+  - ./pkg-build.sh install_bioc_deps
 
 script:
   - ./pkg-build.sh run_tests
@@ -26,3 +26,4 @@ env:
     - RVERSION=devel
   global:
     - _R_CHECK_CRAN_INCOMING_=FALSE
+    - WARNINGS_ARE_ERRORS=TRUE


### PR DESCRIPTION
Switch to using [r-builder](https://github.com/metacran/r-builder) to enable checks against R-devel.
